### PR TITLE
:bug: Fix bug where load balancer was not updated after rollout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>net.azisaba</groupId>
   <artifactId>Kuvel</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <packaging>jar</packaging>
 
   <name>${project.artifactId}</name>

--- a/src/main/java/net/azisaba/kuvel/discovery/impl/RedisLoadBalancerDiscovery.java
+++ b/src/main/java/net/azisaba/kuvel/discovery/impl/RedisLoadBalancerDiscovery.java
@@ -53,11 +53,18 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
                 .withLabel(LabelKeys.SERVER_DISCOVERY.getKey(), "true")
                 .withLabel(LabelKeys.SERVER_NAME.getKey())
                 .watch(
-                    new Watcher<ReplicaSet>() {
+                    new Watcher<>() {
                       @Override
                       public void eventReceived(Action action, ReplicaSet replicaSet) {
                         lock.lock();
                         try {
+                          if (replicaSet.getStatus().getReplicas() <= 0
+                              && replicaSet.getStatus().getObservedGeneration() != null
+                              && replicaSet.getStatus().getObservedGeneration() > 1) {
+                            unregisterOrIgnore(replicaSet);
+                            return;
+                          }
+
                           if (action == Action.ADDED) {
                             registerOrIgnore(replicaSet);
                           } else if (action == Action.DELETED) {
@@ -162,6 +169,11 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
             .list()
             .getItems()
             .stream()
+            .filter(
+                replicaSet ->
+                    replicaSet.getStatus().getReplicas() > 0
+                        || replicaSet.getStatus().getObservedGeneration() == null
+                        || replicaSet.getStatus().getObservedGeneration() <= 1)
             .filter(
                 replicaSet ->
                     !uidAndServerNameMapInRedis.containsKey(replicaSet.getMetadata().getUid()))


### PR DESCRIPTION
Fixed a bug in v1.0.1 where the ReplicaSet was not updated after rollout because there was time for two ReplicaSets to exist when rollout was executed, and LoadBalancer did not work.