### PR TITLE
Make namespace configurable and improve config&logger handling

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -16,6 +16,7 @@ Pluginは [Releases](https://github.com/AzisabaNetwork/Kuvel/releases/latest)
 からダウンロードできます。 `Kuvel.jar` をダウンロードしVelocityに導入してください。ダウンロード後、コンフィグの設定を行ってください。
 
 ```yml
+namespace: ""
 redis:
   group-name: "production" # Redisサーバーが同じかつgroup-nameが同じサーバー間でのみ名前同期が行われます
   connection:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ redis:
     password: "password"
 ```
 
+Alternatively you can use environment variables to configure Kuvel. The environment variable will override
+ the config.yml and are `KUVEL_NAMESPACE`, `KUVEL_REDIS_GROUPNAME`, `KUVEL_REDIS_CONNECTION_HOSTNAME`,
+`KUVEL_REDIS_CONNECTION_PORT`, `KUVEL_REDIS_CONNECTION_USERNAME`, and `KUVEL_REDIS_CONNECTION_PASSWORD`.
+
 In order for Kuvel to monitor the server, you must request permission from Kubernetes to allow
 Velocity pods discovery Minecraft servers. For Velocity pods, please allow get/list/watch to Pods
 and ReplicaSets.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ from [Releases](https://github.com/AzisabaNetwork/Kuvel/releases/latest). Downlo
 install it into Velocity plugins directory. Also, you have to fill in the configuration file.
 
 ```yml
+# The kubernetes namespace to use for the server discovery.
+namespace: ""
 # Server name synchronization by Redis is required in load-balanced environments using multiple Velocity.
 redis:
   group-name: "production"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>net.azisaba</groupId>
   <artifactId>Kuvel</artifactId>
-  <version>2.0.2</version>
+  <version>2.1.0</version>
   <packaging>jar</packaging>
 
   <name>${project.artifactId}</name>

--- a/src/main/java/net/azisaba/kuvel/Kuvel.java
+++ b/src/main/java/net/azisaba/kuvel/Kuvel.java
@@ -5,9 +5,13 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -34,6 +38,7 @@ public class Kuvel {
 
   private final ProxyServer proxy;
   private final Logger logger;
+  private final File dataDirectory;
 
   private KubernetesClient client;
   private KuvelServiceHandler kuvelServiceHandler;
@@ -44,9 +49,10 @@ public class Kuvel {
   private KuvelConfig kuvelConfig;
 
   @Inject
-  public Kuvel(ProxyServer server, Logger logger) {
+  public Kuvel(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
     this.proxy = server;
     this.logger = logger;
+    this.dataDirectory = dataDirectory.toFile();
   }
 
   @Subscribe

--- a/src/main/java/net/azisaba/kuvel/Kuvel.java
+++ b/src/main/java/net/azisaba/kuvel/Kuvel.java
@@ -24,7 +24,7 @@ import net.azisaba.kuvel.redis.RedisSubscriberExecutor;
 @Plugin(
     id = "kuvel",
     name = "Kuvel",
-    version = "2.0.2",
+    version = "2.1.0",
     url = "https://github.com/AzisabaNetwork/Kuvel",
     description =
         "Server-discovery Velocity plugin for Minecraft servers running in a Kubernetes cluster.",
@@ -62,7 +62,7 @@ public class Kuvel {
       return;
     }
 
-    kuvelServiceHandler = new KuvelServiceHandler(this, client);
+    kuvelServiceHandler = new KuvelServiceHandler(this, client, kuvelConfig.getNamespace());
 
     Objects.requireNonNull(kuvelConfig.getRedisConnectionData());
     Objects.requireNonNull(kuvelConfig.getProxyGroupName());
@@ -88,6 +88,7 @@ public class Kuvel {
         new RedisLoadBalancerDiscovery(
             client,
             this,
+            kuvelConfig.getNamespace(),
             kuvelConfig.getRedisConnectionData().createJedisPool(),
             kuvelConfig.getProxyGroupName(),
             redisConnectionLeader,
@@ -97,6 +98,7 @@ public class Kuvel {
         new RedisServerDiscovery(
             client,
             this,
+            kuvelConfig.getNamespace(),
             kuvelConfig.getRedisConnectionData().createJedisPool(),
             kuvelConfig.getProxyGroupName(),
             redisConnectionLeader,

--- a/src/main/java/net/azisaba/kuvel/Kuvel.java
+++ b/src/main/java/net/azisaba/kuvel/Kuvel.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import lombok.Getter;
 import net.azisaba.kuvel.config.KuvelConfig;
 import net.azisaba.kuvel.discovery.impl.redis.RedisLoadBalancerDiscovery;
@@ -24,6 +23,7 @@ import net.azisaba.kuvel.listener.LoadBalancerListener;
 import net.azisaba.kuvel.redis.ProxyIdProvider;
 import net.azisaba.kuvel.redis.RedisConnectionLeader;
 import net.azisaba.kuvel.redis.RedisSubscriberExecutor;
+import org.slf4j.Logger;
 
 @Plugin(
     id = "kuvel",
@@ -63,8 +63,7 @@ public class Kuvel {
     try {
       kuvelConfig.load();
     } catch (Exception e) {
-      logger.severe("Failed to load config file. Plugin feature will be disabled.");
-      e.printStackTrace();
+      logger.error("Failed to load config file. Plugin feature will be disabled.", e);
       return;
     }
 

--- a/src/main/java/net/azisaba/kuvel/KuvelServiceHandler.java
+++ b/src/main/java/net/azisaba/kuvel/KuvelServiceHandler.java
@@ -25,6 +25,7 @@ public class KuvelServiceHandler {
 
   private final Kuvel plugin;
   private final KubernetesClient client;
+  private final String namespace;
   private final HashMap<String, LoadBalancer> loadBalancerServerMap = new HashMap<>();
 
   private final UidAndServerNameMap podUidAndServerNameMap = new UidAndServerNameMap();
@@ -125,7 +126,7 @@ public class KuvelServiceHandler {
     List<Pod> pods =
         client
             .pods()
-            .inAnyNamespace()
+            .inNamespace(namespace)
             .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
             .list()
             .getItems();
@@ -251,7 +252,7 @@ public class KuvelServiceHandler {
     Optional<Pod> pod =
         client
             .pods()
-            .inAnyNamespace()
+            .inNamespace(namespace)
             .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
             .list()
             .getItems()

--- a/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
+++ b/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
@@ -16,6 +16,7 @@ public class KuvelConfig {
 
   private static final String CONFIG_FILE_PATH = "./plugins/Kuvel/config.yml";
 
+  @Nullable private String namespace;
   private boolean redisEnabled;
   @Nullable private RedisConnectionData redisConnectionData;
   @Nullable private String proxyGroupName;
@@ -23,6 +24,8 @@ public class KuvelConfig {
   public void load() throws IOException {
     VelocityConfigLoader conf = VelocityConfigLoader.load(new File(CONFIG_FILE_PATH));
     conf.saveDefaultConfig();
+
+    namespace = conf.getString("namespace", null);
 
     String hostname = conf.getString("redis.connection.hostname");
     int port = conf.getInt("redis.connection.port", -1);

--- a/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
+++ b/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
@@ -14,7 +14,7 @@ public class KuvelConfig {
 
   private final Kuvel plugin;
 
-  private static final String CONFIG_FILE_PATH = "./plugins/Kuvel/config.yml";
+  private static final String CONFIG_FILE_NAME = "config.yml";
 
   @Nullable private String namespace;
   private boolean redisEnabled;
@@ -22,7 +22,7 @@ public class KuvelConfig {
   @Nullable private String proxyGroupName;
 
   public void load() throws IOException {
-    VelocityConfigLoader conf = VelocityConfigLoader.load(new File(CONFIG_FILE_PATH));
+    VelocityConfigLoader conf = VelocityConfigLoader.load(new File(plugin.getDataDirectory(), CONFIG_FILE_NAME));
     conf.saveDefaultConfig();
 
     namespace = conf.getString("namespace", null);

--- a/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
+++ b/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
@@ -23,6 +23,21 @@ public class KuvelConfig {
   @Nullable private String proxyGroupName;
 
   public void load() throws IOException {
+    File uppercaseDataFolder = new File(plugin.getDataDirectory().getParentFile(), "Kuvel");
+    if (uppercaseDataFolder.exists() && !plugin.getDataDirectory().exists()) {
+      if (uppercaseDataFolder.renameTo(plugin.getDataDirectory())) {
+        plugin
+           .getLogger()
+           .info(
+               "Successfully renamed the data folder to use a lowercase name.");
+      } else {
+        plugin
+            .getLogger()
+            .warn(
+                "Failed to rename the data folder to be lowercase. Please manually rename the data folder to 'kuvel'.");
+      }
+    }
+
     VelocityConfigLoader conf = VelocityConfigLoader.load(new File(plugin.getDataDirectory(), CONFIG_FILE_NAME));
     conf.saveDefaultConfig();
 

--- a/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
+++ b/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
@@ -38,7 +38,8 @@ public class KuvelConfig {
       } catch (NumberFormatException e) {
         plugin
             .getLogger()
-            .warning("Invalid port number for Redis connection specified in KUVEL_REDIS_CONNECTION_PORT environment variable. Using port " + port + " from config.yml.");
+            .warn(
+                "Invalid port number for Redis connection specified in KUVEL_REDIS_CONNECTION_PORT environment variable. Using port " + port + " from config.yml.");
       }
     }
     String username = env.getOrDefault("KUVEL_REDIS_CONNECTION_USERNAME", conf.getString("redis.connection.username"));
@@ -48,7 +49,7 @@ public class KuvelConfig {
       redisEnabled = false;
       plugin
           .getLogger()
-          .warning(
+          .warn(
               "Redis is enabled, but hostname or port is invalid. Redis sync will be disabled.");
     } else {
       redisConnectionData = new RedisConnectionData(hostname, port, username, password);

--- a/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisLoadBalancerDiscovery.java
+++ b/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisLoadBalancerDiscovery.java
@@ -32,6 +32,7 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
 
   private final KubernetesClient client;
   private final Kuvel plugin;
+  private final String namespace;
   private final JedisPool jedisPool;
   private final String groupName;
   private final RedisConnectionLeader redisConnectionLeader;
@@ -55,7 +56,7 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
               client
                   .apps()
                   .replicaSets()
-                  .inAnyNamespace()
+                  .inNamespace(namespace)
                   .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
                   .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey())
                   .list()
@@ -241,7 +242,7 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
         client
             .apps()
             .replicaSets()
-            .inAnyNamespace()
+            .inNamespace(namespace)
             .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
             .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey())
             .list()
@@ -272,7 +273,7 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
     return client
         .apps()
         .replicaSets()
-        .inAnyNamespace()
+        .inNamespace(namespace)
         .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
         .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey())
         .list()

--- a/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisServerDiscovery.java
+++ b/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisServerDiscovery.java
@@ -32,6 +32,7 @@ public class RedisServerDiscovery implements ServerDiscovery {
 
   private final KubernetesClient client;
   private final Kuvel plugin;
+  private final String namespace;
   private final JedisPool jedisPool;
   private final String groupName;
   private final RedisConnectionLeader redisConnectionLeader;
@@ -52,7 +53,7 @@ public class RedisServerDiscovery implements ServerDiscovery {
           List<Pod> podList =
               client
                   .pods()
-                  .inAnyNamespace()
+                  .inNamespace(namespace)
                   .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
                   .list()
                   .getItems();
@@ -113,7 +114,7 @@ public class RedisServerDiscovery implements ServerDiscovery {
 
         client
             .pods()
-            .inAnyNamespace()
+            .inNamespace(namespace)
             .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
             .withField("status.phase", "Running")
             .list()

--- a/src/main/java/net/azisaba/kuvel/redis/RedisConnectionLeader.java
+++ b/src/main/java/net/azisaba/kuvel/redis/RedisConnectionLeader.java
@@ -120,6 +120,7 @@ public class RedisConnectionLeader {
             new RedisLoadBalancerDiscovery(
                 plugin.getClient(),
                 plugin,
+                plugin.getKuvelConfig().getNamespace(),
                 plugin.getKuvelConfig().getRedisConnectionData().createJedisPool(),
                 plugin.getKuvelConfig().getProxyGroupName(),
                 this,
@@ -131,6 +132,7 @@ public class RedisConnectionLeader {
             new RedisServerDiscovery(
                 plugin.getClient(),
                 plugin,
+                plugin.getKuvelConfig().getNamespace(),
                 plugin.getKuvelConfig().getRedisConnectionData().createJedisPool(),
                 plugin.getKuvelConfig().getProxyGroupName(),
                 this,

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,5 @@
+# The kubernetes namespace to use for the server discovery.
+namespace: ""
 # Server name synchronization by Redis is required in load-balanced environments using multiple Velocity.
 redis:
   group-name: "production"


### PR DESCRIPTION
This adds the ability to pass the namespace that should be used for discovering servers in. (The default setting of an empty/null namespace should still behave like before and discover in any namespaces)

I also expanded the config handling to allow defining of the options via environment variables as well as loading of the config file from the plugin's DataDirectory directly (this avoids potential issues in environments where `/` is not the path separator or where the DataDirectory is not the default one)

Additionally to that I moved the Logger from JUL to the Velocity-devs suggested slf4j one (and directly included stacktraces in the errors). That results in better compatibility with certain environments as the JUL to slf4j translation which Velocity ships as a fallback can break in some cases. (E.g. when running inside containers it can log as `ERROR` instead of at the proper level)