### PR TITLE
Improve the logging on startup to log missing pods

### DIFF
--- a/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisServerDiscovery.java
+++ b/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisServerDiscovery.java
@@ -155,16 +155,16 @@ public class RedisServerDiscovery implements ServerDiscovery {
       verb = "Found";
     }
 
-    for (String podUid : podIdToServerNameMap.keySet()) {
-      plugin
-          .getLogger()
-          .info(verb + " server: " + podIdToServerNameMap.get(podUid) + " (" + podUid + ")");
-    }
-
     HashMap<String, Pod> servers = new HashMap<>();
     for (Entry<String, String> entry : podIdToServerNameMap.entrySet()) {
+      plugin
+          .getLogger()
+          .info(verb + " server: " + entry.getValue() + " (" + entry.getKey() + ")");
       Pod pod = getPodByUid(entry.getKey());
       if (pod == null) {
+        plugin
+            .getLogger()
+            .warn("Pod " + entry.getKey() + " for server " + entry.getValue() + " not found");
         continue;
       }
 


### PR DESCRIPTION
This adds a log message warning about a missing pod as well as remove the duplicate loop over the pods just to log a message.