### PR TITLE
Add ability to configure the prefix of the label keys

### DIFF
--- a/src/main/java/net/azisaba/kuvel/KuvelServiceHandler.java
+++ b/src/main/java/net/azisaba/kuvel/KuvelServiceHandler.java
@@ -127,7 +127,7 @@ public class KuvelServiceHandler {
         client
             .pods()
             .inNamespace(namespace)
-            .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
+            .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(plugin.getKuvelConfig().getLabelKeyPrefix()), "true")
             .list()
             .getItems();
 
@@ -160,8 +160,8 @@ public class KuvelServiceHandler {
         plugin.getProxy().getServer(entry.getKey()).ifPresent(server -> plugin.getProxy().unregisterServer(server.getServerInfo()));
         plugin.getProxy().registerServer(new ServerInfo(entry.getKey(), address));
 
-        String initialServerStr = pod.getMetadata().getLabels()
-            .getOrDefault(LabelKeys.INITIAL_SERVER.getKey(), "false");
+        String initialServerStr = pod.getMetadata().getLabels().getOrDefault(
+                LabelKeys.INITIAL_SERVER.getKey(plugin.getKuvelConfig().getLabelKeyPrefix()), "false");
         if (Boolean.parseBoolean(initialServerStr)) {
           initialServerNames.add(entry.getKey());
         }
@@ -232,7 +232,8 @@ public class KuvelServiceHandler {
     }
 
     String initialServerStr =
-        pod.getMetadata().getLabels().getOrDefault(LabelKeys.INITIAL_SERVER.getKey(), "false");
+        pod.getMetadata().getLabels().getOrDefault(
+                LabelKeys.INITIAL_SERVER.getKey(plugin.getKuvelConfig().getLabelKeyPrefix()), "false");
     if (Boolean.parseBoolean(initialServerStr)) {
       initialServerNames.add(serverName);
     }
@@ -253,7 +254,8 @@ public class KuvelServiceHandler {
         client
             .pods()
             .inNamespace(namespace)
-            .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
+            .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(
+                    plugin.getKuvelConfig().getLabelKeyPrefix()), "true")
             .list()
             .getItems()
             .stream()

--- a/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
+++ b/src/main/java/net/azisaba/kuvel/config/KuvelConfig.java
@@ -21,6 +21,7 @@ public class KuvelConfig {
   private boolean redisEnabled;
   @Nullable private RedisConnectionData redisConnectionData;
   @Nullable private String proxyGroupName;
+  private String labelKeyPrefix;
 
   public void load() throws IOException {
     File uppercaseDataFolder = new File(plugin.getDataDirectory().getParentFile(), "Kuvel");
@@ -71,5 +72,6 @@ public class KuvelConfig {
     }
 
     proxyGroupName = env.getOrDefault("KUVEL_REDIS_GROUPNAME", conf.getString("redis.group-name", null));
+    labelKeyPrefix = env.getOrDefault("KUVEL_LABEL_KEY_PREFIX", conf.getString("label-key-prefix", "kuvel.azisaba.net"));
   }
 }

--- a/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisLoadBalancerDiscovery.java
+++ b/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisLoadBalancerDiscovery.java
@@ -52,13 +52,14 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
 
     Runnable runnable =
         () -> {
+          String labelKeyPrefix = plugin.getKuvelConfig().getLabelKeyPrefix();
           List<ReplicaSet> replicaSetList =
               client
                   .apps()
                   .replicaSets()
                   .inNamespace(namespace)
-                  .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
-                  .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey())
+                  .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(labelKeyPrefix), "true")
+                  .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix))
                   .list()
                   .getItems();
 
@@ -114,16 +115,17 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
       return;
     }
 
+    String labelKeyPrefix = plugin.getKuvelConfig().getLabelKeyPrefix();
     String serverName =
         replicaSet
             .getMetadata()
             .getLabels()
-            .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(), null);
+            .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix), null);
     boolean initialServer =
         replicaSet
             .getMetadata()
             .getLabels()
-            .getOrDefault(LabelKeys.INITIAL_SERVER.getKey(), "false")
+            .getOrDefault(LabelKeys.INITIAL_SERVER.getKey(labelKeyPrefix), "false")
             .equalsIgnoreCase("true");
 
     if (serverName == null) {
@@ -239,12 +241,13 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
           registerOrIgnore(replicaSet, true);
         }
 
+        String labelKeyPrefix = plugin.getKuvelConfig().getLabelKeyPrefix();
         client
             .apps()
             .replicaSets()
             .inNamespace(namespace)
-            .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
-            .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey())
+            .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(labelKeyPrefix), "true")
+            .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix))
             .list()
             .getItems()
             .stream()
@@ -270,12 +273,13 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
   }
 
   private ReplicaSet getReplicaSetFromUid(String uid) {
+    String labelKeyPrefix = plugin.getKuvelConfig().getLabelKeyPrefix();
     return client
         .apps()
         .replicaSets()
         .inNamespace(namespace)
-        .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
-        .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey())
+        .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(labelKeyPrefix), "true")
+        .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix))
         .list()
         .getItems()
         .stream()

--- a/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisServerDiscovery.java
+++ b/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisServerDiscovery.java
@@ -54,7 +54,7 @@ public class RedisServerDiscovery implements ServerDiscovery {
               client
                   .pods()
                   .inNamespace(namespace)
-                  .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
+                  .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(plugin.getKuvelConfig().getLabelKeyPrefix()), "true")
                   .list()
                   .getItems();
 
@@ -112,10 +112,11 @@ public class RedisServerDiscovery implements ServerDiscovery {
         Map<String, String> loadBalancerMap =
             jedis.hgetAll(RedisKeys.LOAD_BALANCERS_PREFIX.getKey() + groupName);
 
+        String labelKeyPrefix = plugin.getKuvelConfig().getLabelKeyPrefix();
         client
             .pods()
             .inNamespace(namespace)
-            .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(), "true")
+            .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(labelKeyPrefix), "true")
             .withField("status.phase", "Running")
             .list()
             .getItems()
@@ -130,7 +131,7 @@ public class RedisServerDiscovery implements ServerDiscovery {
                       pod.getMetadata()
                           .getLabels()
                           .getOrDefault(
-                              LabelKeys.PREFERRED_SERVER_NAME.getKey(),
+                              LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix),
                               pod.getMetadata().getName());
                   String serverName =
                       getValidServerName(
@@ -233,7 +234,7 @@ public class RedisServerDiscovery implements ServerDiscovery {
       String preferServerName =
           pod.getMetadata()
               .getLabels()
-              .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(), pod.getMetadata().getName());
+              .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(plugin.getKuvelConfig().getLabelKeyPrefix()), pod.getMetadata().getName());
 
       serverName =
           getValidServerName(

--- a/src/main/java/net/azisaba/kuvel/util/LabelKeys.java
+++ b/src/main/java/net/azisaba/kuvel/util/LabelKeys.java
@@ -11,12 +11,12 @@ public enum LabelKeys {
 
   private final String key;
 
-  public String getKey() {
-    return "kuvel.azisaba.net/" + key;
+  public String getKey(String prefix) {
+    return prefix + "/" + key;
   }
 
   @Override
   public String toString() {
-    return getKey();
+    return key;
   }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,7 @@
 # The kubernetes namespace to use for the server discovery.
 namespace: ""
+# The prefix to use for the keys of the server labels.
+label-key-prefix: "kuvel.azisaba.net"
 # Server name synchronization by Redis is required in load-balanced environments using multiple Velocity.
 redis:
   group-name: "production"


### PR DESCRIPTION
This adds the ability to configure the prefix used by label keys. This is done via `label-key-prefix` in the config or the `KUVEL_LABEL_KEY_PREFIX` environment variable. (Default is the original `kuvel.azisaba.net`)

This is useful when you want to have the same servers be used in different proxies with different names.