### PR TITLE
Allow specifying the server name via annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ install it into Velocity plugins directory. Also, you have to fill in the config
 ```yml
 # The kubernetes namespace to use for the server discovery.
 namespace: ""
+# The prefix to use for the keys of the server labels or annotations.
+label-key-prefix: "kuvel.azisaba.net"
 # Server name synchronization by Redis is required in load-balanced environments using multiple Velocity.
 redis:
   group-name: "production"
@@ -32,8 +34,9 @@ redis:
 ```
 
 Alternatively you can use environment variables to configure Kuvel. The environment variable will override
- the config.yml and are `KUVEL_NAMESPACE`, `KUVEL_REDIS_GROUPNAME`, `KUVEL_REDIS_CONNECTION_HOSTNAME`,
-`KUVEL_REDIS_CONNECTION_PORT`, `KUVEL_REDIS_CONNECTION_USERNAME`, and `KUVEL_REDIS_CONNECTION_PASSWORD`.
+ the config.yml and are `KUVEL_NAMESPACE`, `KUVEL_LABEL_KEY_PREFIX`, `KUVEL_REDIS_GROUPNAME`, 
+`KUVEL_REDIS_CONNECTION_HOSTNAME`, `KUVEL_REDIS_CONNECTION_PORT`, `KUVEL_REDIS_CONNECTION_USERNAME`, and 
+`KUVEL_REDIS_CONNECTION_PASSWORD`.
 
 In order for Kuvel to monitor the server, you must request permission from Kubernetes to allow
 Velocity pods discovery Minecraft servers. For Velocity pods, please allow get/list/watch to Pods
@@ -78,6 +81,8 @@ To tell Kuvel that the pod is a Minecraft server, use Label feature of Kubernete
 | kuvel.azisaba.net/enable-server-discovery |true / false|
 |  kuvel.azisaba.net/preferred-server-name  |Name of the server you wish to register with Velocity|
 |     kuvel.azisaba.net/initial-server      |true / false|
+
+If server names longer than 63 characters are desired, the `kuvel.azisaba.net/preferred-server-name` annotation can be used instead of the label.
 
 ### Pod
 

--- a/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisLoadBalancerDiscovery.java
+++ b/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisLoadBalancerDiscovery.java
@@ -3,6 +3,7 @@ package net.azisaba.kuvel.discovery.impl.redis;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.api.scheduler.ScheduledTask;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.net.InetSocketAddress;
@@ -59,7 +60,6 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
                   .replicaSets()
                   .inNamespace(namespace)
                   .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(labelKeyPrefix), "true")
-                  .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix))
                   .list()
                   .getItems();
 
@@ -110,20 +110,25 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
   }
 
   private void registerOrIgnore(ReplicaSet replicaSet, boolean isFetchedFromRedis) {
-    String uid = replicaSet.getMetadata().getUid();
+    ObjectMeta metadata = replicaSet.getMetadata();
+    String uid = metadata.getUid();
     if (kuvelServiceHandler.getReplicaSetUidAndServerNameMap().getServerNameFromUid(uid) != null) {
       return;
     }
 
     String labelKeyPrefix = plugin.getKuvelConfig().getLabelKeyPrefix();
     String serverName =
-        replicaSet
-            .getMetadata()
-            .getLabels()
+        metadata
+            .getAnnotations()
             .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix), null);
+    if (serverName == null) {
+      serverName =
+          metadata
+              .getLabels()
+              .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix), null);
+    }
     boolean initialServer =
-        replicaSet
-            .getMetadata()
+        metadata
             .getLabels()
             .getOrDefault(LabelKeys.INITIAL_SERVER.getKey(labelKeyPrefix), "false")
             .equalsIgnoreCase("true");
@@ -247,10 +252,14 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
             .replicaSets()
             .inNamespace(namespace)
             .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(labelKeyPrefix), "true")
-            .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix))
             .list()
             .getItems()
             .stream()
+            .filter(replicaSet -> {
+              ObjectMeta metadata = replicaSet.getMetadata();
+              return metadata.getAnnotations().containsKey(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix))
+                  || metadata.getLabels().containsKey(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix));
+            })
             .filter(replicaSet -> replicaSet.getStatus().getReplicas() > 0)
             .filter(
                 replicaSet ->
@@ -279,10 +288,14 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
         .replicaSets()
         .inNamespace(namespace)
         .withLabel(LabelKeys.ENABLE_SERVER_DISCOVERY.getKey(labelKeyPrefix), "true")
-        .withLabel(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix))
         .list()
         .getItems()
         .stream()
+        .filter(replicaSet -> {
+          ObjectMeta metadata = replicaSet.getMetadata();
+          return metadata.getAnnotations().containsKey(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix))
+              || metadata.getLabels().containsKey(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix));
+        })
         .filter(replicaSet -> replicaSet.getMetadata().getUid().equals(uid))
         .findAny()
         .orElse(null);

--- a/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisServerDiscovery.java
+++ b/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisServerDiscovery.java
@@ -1,6 +1,7 @@
 package net.azisaba.kuvel.discovery.impl.redis;
 
 import com.velocitypowered.api.scheduler.ScheduledTask;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.text.ParseException;
@@ -10,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -122,17 +124,22 @@ public class RedisServerDiscovery implements ServerDiscovery {
             .getItems()
             .forEach(
                 pod -> {
-                  String uid = pod.getMetadata().getUid();
+                  ObjectMeta metadata = pod.getMetadata();
+                  String uid = metadata.getUid();
                   if (podIdToServerNameMap.containsKey(uid)) {
                     return;
                   }
 
                   String preferServerName =
-                      pod.getMetadata()
-                          .getLabels()
-                          .getOrDefault(
-                              LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix),
-                              pod.getMetadata().getName());
+                      metadata
+                          .getAnnotations()
+                          .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix), null);
+                  if (preferServerName == null) {
+                    preferServerName =
+                        metadata
+                            .getLabels()
+                            .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix), metadata.getName());
+                  }
                   String serverName =
                       getValidServerName(
                           preferServerName,
@@ -231,10 +238,18 @@ public class RedisServerDiscovery implements ServerDiscovery {
       Map<String, String> loadBalancerMap =
           jedis.hgetAll(RedisKeys.LOAD_BALANCERS_PREFIX.getKey() + groupName);
 
+      ObjectMeta metadata = pod.getMetadata();
+      String labelKeyPrefix = plugin.getKuvelConfig().getLabelKeyPrefix();
       String preferServerName =
-          pod.getMetadata()
-              .getLabels()
-              .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(plugin.getKuvelConfig().getLabelKeyPrefix()), pod.getMetadata().getName());
+          metadata
+              .getAnnotations()
+              .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix), null);
+      if (preferServerName == null) {
+        preferServerName =
+            metadata
+                .getLabels()
+                .getOrDefault(LabelKeys.PREFERRED_SERVER_NAME.getKey(labelKeyPrefix), metadata.getName());
+      }
 
       serverName =
           getValidServerName(

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 # The kubernetes namespace to use for the server discovery.
 namespace: ""
-# The prefix to use for the keys of the server labels.
+# The prefix to use for the keys of the server labels or annotations.
 label-key-prefix: "kuvel.azisaba.net"
 # Server name synchronization by Redis is required in load-balanced environments using multiple Velocity.
 redis:


### PR DESCRIPTION
This adds the ability to specify an annotation to be used to get the preferred name of a server instead of just a label as labels have a relatively short maximum length.

The annotation uses the same key as the label (`kuvel.azisaba.net/preferred-server-name` by default) and if the annotation is set it will override the label, otherwise the label will be used like before.

I also added the missing `label-key-prefix` config option to the readme.