### PR TITLE
feat: add forced-host label for Velocity forced hosts support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ buildNumber.properties
 .classpath
 
 # End of https://www.toptal.com/developers/gitignore/api/maven,intellij+all
+
+.vscode/

--- a/README-JP.md
+++ b/README-JP.md
@@ -85,16 +85,18 @@ labelはconfigで指定します。デフォルトでは、`kuvel.azisaba.net/en
 
 また、一部の機能を使用するために以下のlabelを使用します。
 
-|                 Label名                  |          値          |
-|:---------------------------------------:|:-------------------:|
-| kuvel.azisaba.net/preferred-server-name | Velocityに登録したいサーバー名 |
-|    kuvel.azisaba.net/initial-server     |    true / false     |
-| kuvel.azisaba.net/disable-name-suffix   |    true / false     |
-| kuvel.azisaba.net/disable-load-balancer |    true / false     |
+|                 Label名                  |              値               |
+|:---------------------------------------:|:----------------------------:|
+| kuvel.azisaba.net/preferred-server-name |    Velocityに登録したいサーバー名     |
+|    kuvel.azisaba.net/initial-server     |        true / false          |
+| kuvel.azisaba.net/disable-name-suffix   |        true / false          |
+| kuvel.azisaba.net/disable-load-balancer |        true / false          |
+|      kuvel.azisaba.net/forced-host      | このサーバーにルーティングするホスト名 (forced hosts) |
 
 サーバー名が63文字を超える場合は、ラベルではなく`kuvel.azisaba.net/preferred-server-name`のアノテーションを使用してください。
 Podに`kuvel.azisaba.net/disable-name-suffix=true`を設定すると、`preferred-server-name`をそのまま登録します (`-1`などのsuffixを付与しません)。複数レプリカが検出された場合はエラーを出して追加Podを登録しません。単一レプリカのPod向けの設定です。
 ReplicaSetまたはDeploymentのmetadataに`kuvel.azisaba.net/disable-load-balancer=true`を設定すると、そのReplicaSet用の仮想LoadBalancerサーバーは作成されません。配下のPod自体は通常どおり登録されます。
+Pod、Deployment、またはReplicaSetに`kuvel.azisaba.net/forced-host`を設定すると、そのホスト名で接続したプレイヤーは対応するサーバーにルーティングされます。これはVelocityの[forced hosts](https://docs.papermc.io/velocity/configuration/#forced-hosts-section)機能をKubernetesのラベル/アノテーションで動的に設定するものです。
 
 ### Podの場合
 
@@ -108,6 +110,7 @@ metadata:
     kuvel.azisaba.net/preferred-server-name: "test-server" # Kuvelがサーバーの命名をするために必要
     # kuvel.azisaba.net/initial-server: "true" # 初期サーバーにする場合はコメントアウトを外す
     # kuvel.azisaba.net/disable-name-suffix: "true" # preferred-server-nameをそのまま登録する (単一レプリカのみ)
+    # kuvel.azisaba.net/forced-host: "pvp.example.com" # pvp.example.comで接続したプレイヤーをこのサーバーに送る
 spec:
   containers:
     - name: test-server
@@ -134,6 +137,7 @@ spec:
         kuvel.azisaba.net/enable-server-discovery: "true" # KuvelがMinecraftサーバーを見つけるために必要 (Configに依存)
         kuvel.azisaba.net/preferred-server-name: "test-server" # Kuvelがサーバーの命名をするために必要
         # kuvel.azisaba.net/initial-server: "true" # 初期サーバーにする場合はコメントアウトを外す
+        # kuvel.azisaba.net/forced-host: "pvp.example.com" # pvp.example.comで接続したプレイヤーをこのサーバーに送る
     spec:
       containers:
         - name: test-server
@@ -159,6 +163,7 @@ metadata:
     kuvel.azisaba.net/preferred-server-name: "lobby"
     # kuvel.azisaba.net/initial-server: "true" # このロードバランサーを初期サーバーにする場合はコメントアウトを外す
     # kuvel.azisaba.net/disable-load-balancer: "true" # LoadBalancerエントリだけ無効にする場合はコメントアウトを外す
+    # kuvel.azisaba.net/forced-host: "lobby.example.com" # lobby.example.comで接続したプレイヤーをこのロードバランサーに送る
 spec:
   replicas: 3
   selector:

--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ The following labels are also used for some other features.
 |    kuvel.azisaba.net/initial-server     |                     true / false                      |
 | kuvel.azisaba.net/disable-name-suffix   |                     true / false                      |
 | kuvel.azisaba.net/disable-load-balancer |                     true / false                      |
+|      kuvel.azisaba.net/forced-host      |    Hostname to route to this server (forced hosts)    |
 
 If server names longer than 63 characters are desired, the `kuvel.azisaba.net/preferred-server-name` annotation can be used instead of the label.
 If `kuvel.azisaba.net/disable-name-suffix=true` is set on a Pod, Kuvel will register the server name exactly as `preferred-server-name` (no `-1` suffix). If multiple replicas are detected, Kuvel logs an error and skips the extra pods. This label is intended for single-replica Pods only.
 If `kuvel.azisaba.net/disable-load-balancer=true` is set on a ReplicaSet or Deployment metadata, Kuvel will skip creating the virtual load balancer server for that ReplicaSet. The backing Pods are still registered normally.
+If `kuvel.azisaba.net/forced-host` is set on a Pod, Deployment, or ReplicaSet, players connecting via that hostname will be routed to the corresponding server. This mirrors Velocity's [forced hosts](https://docs.papermc.io/velocity/configuration/#forced-hosts-section) feature but is configured dynamically through Kubernetes labels/annotations.
 
 ### Pod
 
@@ -106,6 +108,7 @@ metadata:
     kuvel.azisaba.net/preferred-server-name: "test-server" # Required for Kuvel to name the server
     # kuvel.azisaba.net/initial-server: "true" # Uncomment this line if you want to make this server the initial server.   
     # kuvel.azisaba.net/disable-name-suffix: "true" # Use the exact preferred name (no -1 suffix); single replica only.
+    # kuvel.azisaba.net/forced-host: "pvp.example.com" # Players connecting via pvp.example.com will be sent to this server.
 spec:
   containers:
     - name: test-server
@@ -132,6 +135,7 @@ spec:
         kuvel.azisaba.net/enable-server-discovery: "true" # Required for Kuvel to detect Minecraft servers. Depends on your config.
         kuvel.azisaba.net/preferred-server-name: "test-server" # Required for Kuvel to name the server
         # kuvel.azisaba.net/initial-server: "true" # Uncomment this line if you want to make this server the initial server.
+        # kuvel.azisaba.net/forced-host: "pvp.example.com" # Players connecting via pvp.example.com will be sent to this server.
     spec:
       containers:
         - name: test-server
@@ -158,6 +162,7 @@ metadata:
     kuvel.azisaba.net/preferred-server-name: "lobby"
     # kuvel.azisaba.net/initial-server: "true" # Uncomment this line if you want to make this load balancer server the initial server.
     # kuvel.azisaba.net/disable-load-balancer: "true" # Uncomment this line to disable only the load balancer entry.
+    # kuvel.azisaba.net/forced-host: "lobby.example.com" # Players connecting via lobby.example.com will be sent to this load balancer.
 spec:
   replicas: 3
   selector:

--- a/src/main/java/net/azisaba/kuvel/KuvelServiceHandler.java
+++ b/src/main/java/net/azisaba/kuvel/KuvelServiceHandler.java
@@ -10,8 +10,11 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
@@ -38,6 +41,7 @@ public class KuvelServiceHandler {
   private final UidAndServerNameMap replicaSetUidAndServerNameMap = new UidAndServerNameMap();
 
   private final List<String> initialServerNames = new ArrayList<>();
+  private final Map<String, List<String>> forcedHosts = new ConcurrentHashMap<>();
 
   private final AtomicReference<ServerDiscovery> serverDiscovery = new AtomicReference<>();
   private final AtomicReference<LoadBalancerDiscovery> loadBalancerDiscovery =
@@ -57,6 +61,10 @@ public class KuvelServiceHandler {
 
     if (loadBalancer.isInitialServer() && !initialServerNames.contains(serverName)) {
       initialServerNames.add(serverName);
+    }
+
+    if (loadBalancer.getForcedHost() != null) {
+      addForcedHost(loadBalancer.getForcedHost(), serverName);
     }
 
     plugin
@@ -101,6 +109,7 @@ public class KuvelServiceHandler {
     replicaSetUidAndServerNameMap.unregister(loadBalancer.getReplicaSetUid());
 
     initialServerNames.remove(serverName);
+    removeForcedHost(serverName);
 
     plugin
         .getLogger()
@@ -244,11 +253,24 @@ public class KuvelServiceHandler {
       }
     }
 
+    String labelKeyPrefix = plugin.getKuvelConfig().getLabelKeyPrefix();
     String initialServerStr =
         pod.getMetadata().getLabels().getOrDefault(
-                LabelKeys.INITIAL_SERVER.getKey(plugin.getKuvelConfig().getLabelKeyPrefix()), "false");
+                LabelKeys.INITIAL_SERVER.getKey(labelKeyPrefix), "false");
     if (Boolean.parseBoolean(initialServerStr)) {
       initialServerNames.add(serverName);
+    }
+
+    String forcedHost =
+        pod.getMetadata().getLabels().getOrDefault(
+                LabelKeys.FORCED_HOST.getKey(labelKeyPrefix), null);
+    if (forcedHost == null) {
+      forcedHost =
+          pod.getMetadata().getAnnotations().getOrDefault(
+                  LabelKeys.FORCED_HOST.getKey(labelKeyPrefix), null);
+    }
+    if (forcedHost != null) {
+      addForcedHost(forcedHost, serverName);
     }
 
     plugin
@@ -315,6 +337,7 @@ public class KuvelServiceHandler {
     }
 
     initialServerNames.remove(serverName);
+    removeForcedHost(serverName);
 
     plugin.getLogger().info("Unregistered server: " + serverName + " (" + podUid + ")");
   }
@@ -336,5 +359,18 @@ public class KuvelServiceHandler {
    */
   public boolean isPodRegistered(String podId) {
     return podUidAndServerNameMap.getServerNameFromUid(podId) != null;
+  }
+
+  private void addForcedHost(String hostname, String serverName) {
+    forcedHosts.computeIfAbsent(hostname, k -> new CopyOnWriteArrayList<>()).add(serverName);
+  }
+
+  private void removeForcedHost(String serverName) {
+    forcedHosts.values().forEach(list -> list.remove(serverName));
+    forcedHosts.entrySet().removeIf(entry -> entry.getValue().isEmpty());
+  }
+
+  public Map<String, List<String>> getForcedHosts() {
+    return forcedHosts;
   }
 }

--- a/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisLoadBalancerDiscovery.java
+++ b/src/main/java/net/azisaba/kuvel/discovery/impl/redis/RedisLoadBalancerDiscovery.java
@@ -136,6 +136,16 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
             .getLabels()
             .getOrDefault(LabelKeys.INITIAL_SERVER.getKey(labelKeyPrefix), "false")
             .equalsIgnoreCase("true");
+    String forcedHost =
+        metadata
+            .getLabels()
+            .getOrDefault(LabelKeys.FORCED_HOST.getKey(labelKeyPrefix), null);
+    if (forcedHost == null) {
+      forcedHost =
+          metadata
+              .getAnnotations()
+              .getOrDefault(LabelKeys.FORCED_HOST.getKey(labelKeyPrefix), null);
+    }
     if (isDisableLoadBalancer(metadata)) {
       return;
     }
@@ -169,7 +179,7 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
       kuvelServiceHandler.getReplicaSetUidAndServerNameMap().register(uid, serverName);
       jedis.hset(RedisKeys.LOAD_BALANCERS_PREFIX.getKey() + groupName, uid, serverName);
 
-      redisConnectionLeader.publishNewLoadBalancer(uid, serverName, initialServer);
+      redisConnectionLeader.publishNewLoadBalancer(uid, serverName, initialServer, forcedHost);
 
       RegisteredServer server =
           plugin
@@ -182,7 +192,8 @@ public class RedisLoadBalancerDiscovery implements LoadBalancerDiscovery {
               server,
               new RoundRobinLoadBalancingStrategy(),
               uid,
-              initialServer));
+              initialServer,
+              forcedHost));
     }
   }
 

--- a/src/main/java/net/azisaba/kuvel/listener/ChooseInitialServerListener.java
+++ b/src/main/java/net/azisaba/kuvel/listener/ChooseInitialServerListener.java
@@ -4,6 +4,7 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.player.PlayerChooseInitialServerEvent;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +20,21 @@ public class ChooseInitialServerListener {
 
   @Subscribe
   public void onInitialServerChoose(PlayerChooseInitialServerEvent event) {
+    Optional<InetSocketAddress> virtualHost = event.getPlayer().getVirtualHost();
+    if (virtualHost.isPresent()) {
+      String hostname = virtualHost.get().getHostString();
+      List<String> forcedServerNames = handler.getForcedHosts().get(hostname);
+      if (forcedServerNames != null && !forcedServerNames.isEmpty()) {
+        for (String serverName : forcedServerNames) {
+          Optional<RegisteredServer> optionalServer = proxy.getServer(serverName);
+          if (optionalServer.isPresent()) {
+            event.setInitialServer(optionalServer.get());
+            return;
+          }
+        }
+      }
+    }
+
     if (handler.getInitialServerNames().isEmpty()) {
       return;
     }

--- a/src/main/java/net/azisaba/kuvel/loadbalancer/LoadBalancer.java
+++ b/src/main/java/net/azisaba/kuvel/loadbalancer/LoadBalancer.java
@@ -19,6 +19,7 @@ public class LoadBalancer {
   private final String replicaSetUid;
 
   private final boolean isInitialServer;
+  private final String forcedHost;
   private final List<String> endpointServers = new ArrayList<>();
 
   public void addEndpoint(String serverName) {

--- a/src/main/java/net/azisaba/kuvel/redis/RedisConnectionLeader.java
+++ b/src/main/java/net/azisaba/kuvel/redis/RedisConnectionLeader.java
@@ -80,11 +80,11 @@ public class RedisConnectionLeader {
   }
 
   public void publishNewLoadBalancer(
-      String replicaSetUid, String serverName, boolean initialServer) {
+      String replicaSetUid, String serverName, boolean initialServer, String forcedHost) {
     try (Jedis jedis = jedisPool.getResource()) {
       jedis.publish(
           RedisKeys.LOAD_BALANCER_ADDED_NOTIFY_PREFIX.getKey() + groupName,
-          replicaSetUid + ":" + serverName + ":" + initialServer);
+          replicaSetUid + ":" + serverName + ":" + initialServer + ":" + (forcedHost != null ? forcedHost : ""));
     }
   }
 

--- a/src/main/java/net/azisaba/kuvel/redis/RedisSubscriber.java
+++ b/src/main/java/net/azisaba/kuvel/redis/RedisSubscriber.java
@@ -45,6 +45,10 @@ public class RedisSubscriber extends JedisPubSub {
       String replicaSetUid = message.split(":")[0];
       String serverName = message.split(":")[1];
       boolean initialServer = Boolean.parseBoolean(message.split(":")[2]);
+      String forcedHost = message.split(":").length > 3 ? message.split(":")[3] : null;
+      if (forcedHost != null && forcedHost.isEmpty()) {
+        forcedHost = null;
+      }
 
       RegisteredServer server =
           plugin
@@ -56,7 +60,8 @@ public class RedisSubscriber extends JedisPubSub {
               server,
               new RoundRobinLoadBalancingStrategy(),
               replicaSetUid,
-              initialServer);
+              initialServer,
+              forcedHost);
       kuvelServiceHandler.registerLoadBalancer(loadBalancer);
     } else if (channel.startsWith(RedisKeys.POD_DELETED_NOTIFY_PREFIX.getKey())) {
       kuvelServiceHandler.unregisterPod(message);

--- a/src/main/java/net/azisaba/kuvel/util/LabelKeys.java
+++ b/src/main/java/net/azisaba/kuvel/util/LabelKeys.java
@@ -9,6 +9,7 @@ public enum LabelKeys {
   INITIAL_SERVER("initial-server"),
   DISABLE_NAME_SUFFIX("disable-name-suffix"),
   DISABLE_LOAD_BALANCER("disable-load-balancer"),
+  FORCED_HOST("forced-host"),
   ;
 
   private final String key;


### PR DESCRIPTION
Add a new 'forced-host' label/annotation that can be set on Pods and ReplicaSets to configure Velocity's forced hosts functionality. Players connecting via a specific hostname will be routed to the server with the matching forced-host label.

See: https://docs.papermc.io/velocity/configuration/\#forced-hosts-section

Resolves #70 